### PR TITLE
Refactor: add resource destroy function

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -90,7 +90,11 @@ function App() {
 				const lottie:LottieAnimation = lottieEntity.getComponent(LottieAnimation);
 				lottie.isLooping = true;
 				// lottie.speed = 0.05;
+				// destroy resource if need not clone
+				lottie.resource.destroy();
 				lottie.play();
+
+				// lottieEntity.clone();
 
 				// test destroy
 				// setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vite": "1.0.0-rc.5",
     "vite-plugin-react": "^3.0.0"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Lottie runtime of oasis engine",
   "name": "@oasis-engine/lottie",
   "ci": {

--- a/src/LottieResource.ts
+++ b/src/LottieResource.ts
@@ -56,7 +56,6 @@ export class LottieResource extends EngineObject {
   height: number;
   width: number;
   layers: TypeLayer[];
-  animations: any[];
   comps: any[];
   atlas: any;
   name: string;
@@ -170,5 +169,12 @@ export class LottieResource extends EngineObject {
 
   private _isObject(obj: Object) {
     return (typeof obj === "object" || typeof obj === "function") && typeof obj !== null;
+  }
+
+  destroy(): void {
+    this.layers = null;
+    this.clips = null;
+    this.comps = null;
+    this.atlas = null;
   }
 }


### PR DESCRIPTION
User can destroy the memory of `LottieResource` when loading ends.  Look into the diffs of `App.tsx`.

If you want to clone the entity, don't destroy the resource immediately, because the clone logic depends on the resource.