### PR TITLE
修复 lottie 节点销毁导致纹理异常的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.8.4",
     "vite": "^4.3.9"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Lottie runtime of oasis engine",
   "name": "@galacean/engine-lottie",
   "repository": "https://github.com/galacean/engine-lottie.git",

--- a/src/LottieResource.ts
+++ b/src/LottieResource.ts
@@ -198,11 +198,11 @@ export class LottieResource extends EngineObject {
   }
 
   destroy(): void {
+    this.atlas.destroy();
+    this.atlas = null;
     this.layers = null;
     this.clips = null;
     this.comps = null;
-    this.atlas.destroy(true);
-    this.atlas = null;
 
     super.destroy();
   }

--- a/src/element/SpriteLottieElement.ts
+++ b/src/element/SpriteLottieElement.ts
@@ -40,7 +40,6 @@ export default class SpriteLottieElement extends BaseLottieElement {
 
   destroy() {
     super.destroy();
-    this.sprite?.texture?.destroy();
     this.sprite = null;
     this.spriteRenderer = null;
   }


### PR DESCRIPTION
这行代码的职责有问题，节点或组件的销毁只会影响资产的引用计数，只有销毁 `LottieResource` 资产的时候才可能会连带销毁图集资产和纹理资产