### PR TITLE
修复 layer 的 ind 缺省情况下导致 Render.priority 有误的问题

### DIFF
--- a/src/LottieResource.ts
+++ b/src/LottieResource.ts
@@ -156,7 +156,7 @@ export class LottieResource extends EngineObject {
 
     for (let i = 0, l = layers.length; i < l; i++) {
       const layer = layers[i];
-      layersMap[layer.ind ??= i] = layer;
+      layersMap[layer.ind ?? i] = layer;
     }
 
     for (let i = layers.length - 1; i >= 0; i--) {
@@ -164,7 +164,7 @@ export class LottieResource extends EngineObject {
       const { refId, parent } = layer;
       layer.offsetTime = startTime;
       layer.stretch = stretch;
-      layer.index = layer.ind * indFactor + indStart;
+      layer.index = (layer.ind ?? i) * indFactor + indStart;
       if (parent) {
         if (!layersMap[parent].layers) {
           layersMap[parent].layers = [];
@@ -182,7 +182,8 @@ export class LottieResource extends EngineObject {
         }
         const offsetTime = (layer.offsetTime || 0) + (layer.st || 0);
         const stretch = (layer.stretch || 1) * (layer.sr || 1);
-        const compIndFactor = (indFactor / (refLayers[refLayers.length - 1].ind + 1)) * indFactor;
+        const lastIndex = refLayers.length - 1;
+        const compIndFactor = (indFactor / ((refLayers[lastIndex].ind ?? lastIndex) + 1)) * indFactor;
         this._buildTree(refLayers, compsMap, offsetTime, stretch, layer.index, compIndFactor);
         if (layer.layers) {
           layer.layers.push(...refLayers);

--- a/src/LottieResource.ts
+++ b/src/LottieResource.ts
@@ -104,7 +104,15 @@ export class LottieResource extends EngineObject {
       for (let i = 0, l = comps.length; i < l; i++) {
         const comp = comps[i];
         if (comp.id) {
+          // comps 内包含的 comp 是 prefab 的模型
           compsMap[comp.id] = comp;
+          const layers = comp.layers;
+          if (layers) {
+            // 预处理 comp 内的 layer，补全 ind 字段
+            for (let j = 0; j < layers.length; j++) {
+              layers[j].ind ??= j;
+            }
+          }
         }
       }
     }
@@ -148,7 +156,7 @@ export class LottieResource extends EngineObject {
 
     for (let i = 0, l = layers.length; i < l; i++) {
       const layer = layers[i];
-      layersMap[layer.ind] = layer;
+      layersMap[layer.ind ??= i] = layer;
     }
 
     for (let i = layers.length - 1; i >= 0; i--) {

--- a/src/LottieResource.ts
+++ b/src/LottieResource.ts
@@ -104,15 +104,7 @@ export class LottieResource extends EngineObject {
       for (let i = 0, l = comps.length; i < l; i++) {
         const comp = comps[i];
         if (comp.id) {
-          // comps 内包含的 comp 是 prefab 的模型
           compsMap[comp.id] = comp;
-          const layers = comp.layers;
-          if (layers) {
-            // 预处理 comp 内的 layer，补全 ind 字段
-            for (let j = 0; j < layers.length; j++) {
-              layers[j].ind ??= j;
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
「如果 ind 属性的值与图层在数组中的位置索引一致，插件可能会选择省略这个冗余信息来减小文件体积。」